### PR TITLE
Include `.env.local` file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export default function dotenvPlugin(inputOptions) {
       )([
         `.env.${process.env[envKey]}.local`,
         `.env.${process.env[envKey]}`,
+        '.env.local',
         '.env',
       ]),
     ),


### PR DESCRIPTION
I notice this plugin not include '.env.local' file. so, patch it.